### PR TITLE
use urls which are configured in the admin list configurator as much as possible

### DIFF
--- a/Resources/views/Translator/addTranslation.html.twig
+++ b/Resources/views/Translator/addTranslation.html.twig
@@ -1,19 +1,13 @@
 {% extends 'KunstmaanTranslatorBundle::Default/layout.html.twig' %}
 
-{% block subbreadcrumb %}
-    <li><a href="{{ path('KunstmaanAdminBundle_settings') }}">{{ 'settings.title' | trans }}</a></li>
-    <li><a href="{{ path('KunstmaanAdminBundle_settings_translations') }}">{{ 'settings.translations' | trans }}</a></li>
-    <li class="active">{{ 'settings.translation.add' | trans }}</li>
-{% endblock %}
-
 {% block content %}
     {% form_theme form 'KunstmaanAdminBundle:Form:fields.html.twig' %}
-    <form class="form-horizontal" action="{{ path('KunstmaanTranslatorBundle_settings_translations_add') }}" method="post" {{ form_enctype(form) }} novalidate>
+    <form class="form-horizontal" action="{{ path(app.request.attributes.get('_route'), my_router_params()) }}" method="post" {{ form_enctype(form) }} novalidate>
         <fieldset>
             {{ form_rest(form) }}
             <div class="form-actions">
                 <button class="btn btn-primary" type="submit">{{ 'settings.translation.add' | trans }}</button>
-                <button onclick="window.location = '{{ path('KunstmaanTranslatorBundle_settings_translations') }}'" type="reset" class="btn">{{ 'form.cancel' | trans }}</button>
+                <button onclick="window.location = '{{ path(adminlistconfigurator.getIndexUrl()["path"], adminlistconfigurator.getIndexUrl()["params"]) }}'" type="reset" class="btn">{{ 'form.cancel' | trans }}</button>
             </div>
         </fieldset>
     </form>

--- a/Resources/views/Translator/editTranslation.html.twig
+++ b/Resources/views/Translator/editTranslation.html.twig
@@ -1,19 +1,13 @@
 {% extends 'KunstmaanTranslatorBundle::Default/layout.html.twig' %}
 
-{% block subbreadcrumb %}
-    <li><a href="{{ path('KunstmaanAdminBundle_settings') }}">{{ 'settings.title' | trans }}</a></li>
-    <li><a href="{{ path('KunstmaanAdminBundle_settings_translations') }}">{{ 'settings.translations' | trans }}</a></li>
-    <li class="active">{{ 'settings.translation.edit' | trans }}</li>
-{% endblock %}
-
 {% block content %}
     {% form_theme form 'KunstmaanAdminBundle:Form:fields.html.twig' %}
-    <form class="form-horizontal" action="{{ path('KunstmaanTranslatorBundle_settings_translations_edit', { 'id' : translation.id }) }}" method="post" {{ form_enctype(form) }} novalidate >
+    <form class="form-horizontal" action="{{ path(app.request.attributes.get('_route'), my_router_params()) }}" method="post" {{ form_enctype(form) }} novalidate >
         <fieldset>
             {{ form_rest(form) }}
             <div class="form-actions">
                 <button class="btn btn-primary" type="submit">{{ 'settings.translation.edit' | trans }}</button>
-                <button onclick="window.location = '{{ path('KunstmaanTranslatorBundle_settings_translations') }}'" type="reset" class="btn">{{ 'form.cancel' | trans }}</button>
+                <button onclick="window.location = '{{ path(adminlistconfigurator.getIndexUrl()["path"], adminlistconfigurator.getIndexUrl()["params"]) }}'" type="reset" class="btn">{{ 'form.cancel' | trans }}</button>
             </div>
         </fieldset>
     </form>

--- a/Resources/views/Translator/list.html.twig
+++ b/Resources/views/Translator/list.html.twig
@@ -4,7 +4,12 @@
     <div class="extra_actions_header">
         <div class="btn-group pull-right">
 
-            <a class="btn btn-primary btn-medium" href="{{ path('KunstmaanTranslatorBundle_settings_translations_add') }}">Add translation</a>
+            {% if adminlist.canAdd() %}
+                {% set adminaddlist = adminlist.getAddUrlFor(adminlist.getIndexUrl()['params']) %}
+                {% for key,add in adminaddlist %}
+                    <a class="btn btn-primary btn-medium" href="{{ path(add["path"], add[("params")]) }}">Add translation</a>
+                {% endfor %}
+            {%  endif %}
 
             <a class="btn btn-primary btn-medium" href="{{ path('KunstmaanTranslatorBundle_command_clear_cache') }}">Refresh live</a>
 


### PR DESCRIPTION
This makes it easier to override and implement custom translation editor
