### PR TITLE
Wrong translation was selected for the empty text

### DIFF
--- a/Controller/TranslatorController.php
+++ b/Controller/TranslatorController.php
@@ -73,7 +73,7 @@ class TranslatorController extends AdminListController
 
         $locales = $this->container->getParameter('kuma_translator.managed_locales');
 
-        $choicesText = $this->get('translator')->trans('settings.translator.succesful_added');
+        $choicesText = $this->get('translator')->trans('settings.translator.choose_language');
         $form = $this->createForm(new TranslationAdminType(), $translation);
         $form->add('locale','language', array('choices' => array_combine($locales, $locales), 'empty_value' => $choicesText));
         $form->add('domain','text');

--- a/Resources/translations/messages.en.yml
+++ b/Resources/translations/messages.en.yml
@@ -11,5 +11,5 @@ settings:
         import_translations_forced: Import forced
         not_live_warning: "Translations on the live website aren't up to date, hit 'Refresh live' to update to the latest translations."
         choose_language: "Choose a language"
-        succesful_added: "Translation succesful created"
-        succesful_edited: "Translation succesful edited"
+        succesful_added: "Translation successful created"
+        succesful_edited: "Translation successful edited"


### PR DESCRIPTION
fix for #18
Also fix spelling mistake.
Tests are passing.
